### PR TITLE
chore(deps): upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - run: bun run lint
@@ -17,7 +17,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - run: bun test
@@ -25,7 +25,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - run: bun run build
@@ -39,9 +39,9 @@ jobs:
           - 24
           - 22
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: bun install --production
@@ -53,9 +53,9 @@ jobs:
     if: github.event_name == 'push'
     needs: [lint, test, build, smoke-test]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: bun install


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v4 to v6
- Upgrade `actions/setup-node` from v4 to v6
- `oven-sh/setup-bun` already at latest (v2)

## Test plan
- [ ] Verify CI passes on all jobs (lint, test, build, smoke-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)